### PR TITLE
Fix rnadiff annotation and kegg pathways download/reuse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ snakemake>=7.16
 scikit-learn
 scipy
 seaborn
+selenium
 statsmodels
 tqdm
 xlrd

--- a/sequana/rnadiff.py
+++ b/sequana/rnadiff.py
@@ -704,8 +704,8 @@ class RNADiffResults:
                 logger.warning("Since you provided a GFF file you must provide the feature and attribute to be used.")
             self.annotation = self.read_annot(gff)
         else:
-            self.annotation = pd.read_csv(self.path / "rnadiff.csv", index_col=0, header=[0, 1])
-            self.annotation = self.annotation["annotation"]
+            annots = pd.read_csv(self.path / "rnadiff.csv", index_col=0, header=[0, 1])
+            self.annotation = annots.loc[:, "annotation"]
 
         # some filtering attributes
         self._alpha = alpha
@@ -793,9 +793,6 @@ class RNADiffResults:
         # It may happen that a GFF has duplicated IDs ! For instance ecoli
         # has 20 duplicated ID that are part 1 and 2 of the same gene
         df = df[~df.index.duplicated(keep="last")]
-
-        df.columns = pd.MultiIndex.from_product([["annotation"], df.columns])
-
         return df
 
     def _get_total_df(self, filtered=False):
@@ -830,7 +827,9 @@ class RNADiffResults:
         df.loc[:, ("statistics", "significative_comparisons")] = sign_compa
 
         if self.annotation is not None:
-            df = pd.concat([self.annotation, df], axis=1)
+            annot = self.annotation.copy()
+            annot.columns = pd.MultiIndex.from_product([["annotation"], annot.columns])
+            df = pd.concat([annot, df], axis=1)
 
         return df
 

--- a/sequana/scripts/main/taxonomy.py
+++ b/sequana/scripts/main/taxonomy.py
@@ -60,5 +60,5 @@ def taxonomy(**kwargs):
             # maybe it is a taxon ID ?
             f4 = df[[True if pattern in str(x) else False for x in df.taxon_id]]
             indices = list(f4.index)
-        indices = set(indices)
+        indices = list(set(indices))
         print(df.loc[indices])

--- a/test/enrichment/test_kegg.py
+++ b/test/enrichment/test_kegg.py
@@ -6,35 +6,32 @@ import glob
 from . import test_dir
 
 
-
 def test_ke(tmpdir):
     up = pd.read_csv(f"{test_dir}/data/ecoli_up_gene.csv")
     down = pd.read_csv(f"{test_dir}/data/ecoli_down_gene.csv")
     up = list(up.Name)
     down = list(down.Name)
-    gene_lists = {'up': up, 'down': down, 'all': up +down}
+    gene_lists = {"up": up, "down": down, "all": up + down}
 
     from sequana import logger
-    logger.setLevel('INFO')
-    ke = KEGGPathwayEnrichment(gene_lists, "eco",
-            preload_directory=f"{test_dir}/data/kegg_pathways/")
+
+    logger.setLevel("INFO")
+    ke = KEGGPathwayEnrichment(gene_lists, "eco", preload_directory=f"{test_dir}/data/kegg_pathways/")
 
     with pytest.raises(ValueError):
-        ke.barplot('dummy')
+        ke.barplot("dummy")
 
-    ke.barplot('up')
-    ke.barplot('down')
+    ke.barplot("up")
+    ke.barplot("down")
     ke.plot_genesets_hist()
-    ke.scatterplot('down')
+    ke.scatterplot("down")
     assert ke.find_pathways_by_gene("moaA")
 
-
     # save one pathway (just one to speed up things)
-    outpng = tmpdir.join('test.png')
+    outpng = tmpdir.join("test.png")
     df = pd.read_csv(f"{test_dir}/data/ecoli_all_gene.csv", index_col=0)
-    ke.save_pathway('eco04122', df, filename=outpng)
+    ke.save_pathway("eco04122", df, filename=outpng)
 
     # save all pathways (same as input)
     path = tmpdir.mkdir("pathways_tmp")
-    ke.export_pathways_to_json(str(path))
-
+    ke.save_pathways(str(path))


### PR DESCRIPTION
- Now RNADiffResults.annotation have the same structure either coming from gff file or an already analysed rnadiff folder.
- Fix kegg enrichment error (division by 0) when no DEGs
- simplification: sequana enrichment-kegg now use the rnadiff folder as argument (not the rnadiff.csv)
- Fix sequana taxonomy: sets cannot be used as indices anymore
- remove redundant export_pathways_to_json